### PR TITLE
Dymola HTML export is saved to help/ by default,

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dymosim.exp
 dymosim.lib
 empty.txt
 failure
+help/
 request
 stat
 status


### PR DESCRIPTION
ignoring this directoy