### PR TITLE
each element in the array

### DIFF
--- a/BuildingSystems/Technologies/ThermalStorages/FluidStorage.mo
+++ b/BuildingSystems/Technologies/ThermalStorages/FluidStorage.mo
@@ -175,10 +175,10 @@ public
     "Initial storage temperature"
     annotation(Dialog(tab="Initialization"));
   Modelica.Blocks.Interfaces.RealOutput T[nEle](
-    final quantity="ThermodynamicTemperature",
-    final unit = "K",
-    min=0,
-    displayUnit = "degC")
+    each final quantity="ThermodynamicTemperature",
+    each final unit = "K",
+    each min=0,
+    each displayUnit = "degC")
     "Starting at bottom"
     annotation (Placement(transformation(extent={{-20,-20},{20,20}},rotation=180,origin={-114,40}),iconTransformation(extent={{-64,50},{-84,70}})));
   BuildingSystems.Fluid.MixingVolumes.MixingVolume vol_bot(


### PR DESCRIPTION
`T[nEle](each final unit = "K")`

warning in OM testing should go away:
- https://libraries.openmodelica.org/branches/master/BuildingSystems/files/BuildingSystems_BuildingSystems.Technologies.ThermalStorages.Examples.FluidStorage.err
- https://libraries.openmodelica.org/branches/master/BuildingSystems/files/BuildingSystems_BuildingSystems.Technologies.SolarThermal.Examples.BigCollectorInstallationWithStorage.err
- https://libraries.openmodelica.org/branches/master/BuildingSystems/files/BuildingSystems_BuildingSystems.Technologies.Cogeneration.Examples.CogenerationUnitWithStorage.err
- https://libraries.openmodelica.org/branches/master/BuildingSystems/files/BuildingSystems_BuildingSystems.Technologies.SolarThermal.Examples.SingleCollectorWithStorageTest.err
- https://libraries.openmodelica.org/branches/master/BuildingSystems/files/BuildingSystems_BuildingSystems.Technologies.ThermalStorages.Examples.FluidStorageChargeDischargeProfile.err