### PR TITLE
refactor softcut_upper

### DIFF
--- a/BuildingSystems/Utilities/SmoothFunctions/softcut_upper.mo
+++ b/BuildingSystems/Utilities/SmoothFunctions/softcut_upper.mo
@@ -4,20 +4,11 @@ function softcut_upper "Softly cuts to upper limit"
   input Real x_ulimit;
   input Real r;
   output Real y;
-protected
-  Real x_start;
-  Real x_end;
-  Real help;
-  Real SQRT_TWO = 1.4142135624;
+
 algorithm
-    x_start := x_ulimit - r * (1.0-1.0/SQRT_TWO);
-    x_end := x_start + r/SQRT_TWO;
-    if x <= x_start then
-      y := x;
-    elseif x >= x_end then
-      y := x_ulimit;
-    else
-      help := x_ulimit - x - r * (1.0 - SQRT_TWO);
-      y := x_ulimit - r + sqrt(r*r - help*help);
-    end if;
+  y :=     if x <= x_ulimit - r + r/sqrt(2) then x
+       elseif x >= x_ulimit - r + r*sqrt(2) then x_ulimit
+       else x_ulimit - r + sqrt(r^2 - (x_ulimit - x - r + r*sqrt(2))^2);
+
+  annotation (Inline=true, smoothOrder=1);
 end softcut_upper;


### PR DESCRIPTION
Dymola can only inline functions if no intermediate variables are used,
and the if-else condition has to be written in the y = if cond then x form.

Also see https://github.com/xogeny/ModelicaBook/issues/338

This is a first example for #10.

Also related: https://github.com/ibpsa/modelica-ibpsa/issues/169
Also related: https://kb.dsxclient.3ds.com/mashup-ui/page/document?q=docid:SR00453610