### PR TITLE
Update MSL version to 3.2.3

### DIFF
--- a/BuildingSystems/package.mo
+++ b/BuildingSystems/package.mo
@@ -8,7 +8,7 @@ package BuildingSystems
     versionBuild=0,
     versionDate="2017-04-10",
     dateModified = "2017-04-10",
-    uses(Modelica(version="3.2.2"),NcDataReader2(version="2.4.0")),
+    uses(Modelica(version="3.2.3"),NcDataReader2(version="2.4.0")),
     preferredView="info",
     Icon(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,100}}),graphics={
     Polygon(points={{-34,62},{0,88},{30,62},{-34,62}},lineColor={0,0,0},fillColor={135,135,135},fillPattern=FillPattern.Solid),


### PR DESCRIPTION
MSL 3.2.3 has been released almost one year ago, with some maintenance fixes, and is currently the standard version used by all Modelica tools. I would recommend you use it for your library