### PR TITLE
JModelica deprecated

### DIFF
--- a/BuildingSystems/Resources/Scripts/JModelica/README.md
+++ b/BuildingSystems/Resources/Scripts/JModelica/README.md
@@ -1,13 +1,13 @@
 JModelica
 =========
 
-The majority of the examples of the BuildingSystems library are running with [JModelica](https://jmodelica.org/).
+The majority of the examples of the BuildingSystems library are running with [JModelica](https://en.wikipedia.org/wiki/JModelica.org).
 
 To perform a simulation experiment with JModelica following preparation steps have to be done:
 
 ## Installation of JModelica
-Download JModelica from [JModelica.org](https://jmodelica.org).
-The easiest way is to install the [Windows installer](https://jmodelica.org/downloads/JModelica.org-2.2.exe).
+Download JModelica from [JModelica](https://github.com/JModelica/JModelica).
+The easiest way is to install the [Windows installer](https://github.com/JModelica/JModelica/releases).
 
 ## Running a simulation experiment
 The folder BuildingSystems/Resources/Scripts/JModelica contains Python Scripts


### PR DESCRIPTION
Sadly Modelon has deprecated the JModelica project. I'm trying to revive it and the edits refer to the latest source code and binary provided by the company. I would like also to invite you to join that project and also join the [Modelica Language Discord server](https://discordapp.com/invite/bp2yeYU).